### PR TITLE
bugfix: cjk separator is too large

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "styles-wc",
-  "version": "4.1.10",
+  "version": "4.1.12",
   "description": "Global styles for the FamilySearch.org website.",
   "keywords": [
     "css",

--- a/fs-person-eol/fs-person-eol.html
+++ b/fs-person-eol/fs-person-eol.html
@@ -266,6 +266,7 @@ fs-person-eol:not([inline]) {
         margin-bottom: 2px;
         padding-right: 6px;
         padding-left: 6px;
+        font-family: Verdana, sans-serif;
       }
 
       /* The actual popup (appears on top) */


### PR DESCRIPTION
CJK person separator was too large because we use different fonts for CJK. Fixed it by using verdana font for separator only. Bumped to 4.1.12 because fs-webdev/styles-wc has a version 4.1.11

## To-Dos
- [ ] Tests
- [ ] Update demo
- [ ] Update documentation & README
- [ ] Increment bower.json version
